### PR TITLE
make pecl install task idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,6 @@
 - name: Install PECL libaries.
   command: pecl install {{ item }}
   register: pecl_result
-  changed_when: "'already installed' not in pecl_result.stdout"
-  failed_when: "pecl_result.stderr"
+  changed_when: "pecl_result.rc == 0"
+  failed_when: "not ('already installed' in pecl_result.stdout or 'install ok:' in pecl_result.stdout)"
   with_items: php_pecl_extensions


### PR DESCRIPTION
After making this change, I'm able to run the task any number of times without error when the pecl libraries are already installed.

Thanks for your ansible work.
