### PR TITLE
Fixed "error while evaluating conditional"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,5 @@
   command: "pecl install {{ item }}"
   register: pecl_result
   changed_when: "pecl_result.rc == 0"
-  failed_when: "not (('already installed' in pecl_result.stdout) or ('install ok:' in pecl_result.stdout))"
+  failed_when: "not (('already installed' in pecl_result.stdout|default()) or ('install ok:' in pecl_result.stdout|default()))"
   with_items: php_pecl_extensions


### PR DESCRIPTION
When the role fails it doesn't always generate a stdout (i.e. because PEAR isn't installed), so ansible fails when checking the failed_when conditional rather than the real error message:

fatal: [127.0.0.1] => error while evaluating conditional: not (('already installed' in pecl_result.stdout) or ('install ok:' in pecl_result.stdout))

When the actual error is:
failed: [127.0.0.1] => (item=xdebug) => {"changed": false, "cmd": "pecl install xdebug", "failed": true, "failed_when_result": true, "item": "xdebug", "rc": 2}
msg: [Errno 2] No such file or directory

So I've just added a default of null to the variables. I wasn't sure if PECL always returns a stdout so I didn't just want to always fail when there's no stdout, but I can change it if you think that's the better solution?

_Feel free to reject this PR if you think this is a non-issue, since the readme.md does state that PECL is required anyway_

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/geerlingguy/ansible-role-php-pecl/3)

<!-- Reviewable:end -->
