### PR TITLE
Update PECL channels

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Updating PECL channels.
+  shell: pecl update-channels
+  register: pecl_updatechannels
+  changed_when: "'succeeded' in pecl_updatechannels"
 - name: Install PECL libaries.
   shell: "yes \"\" | {{ php_pecl_install_command }} {{ item }}"
   register: pecl_result


### PR DESCRIPTION
On occasion I've been running into issues while installing PECL libraries. 

````
TASK [geerlingguy.php-pecl : Install PECL libaries.] ***************************
[redacted]
 "stdout_lines": ["WARNING: channel \"pecl.php.net\" has updated its protocols, use \"pecl channel-update pecl.php.net\" to update",
[redacted]
````

This PR adds the `pecl update-channels` command to ensure channels are up-to-date before the installation is run.

----

edit: not having much luck with Travis

> The command "docker pull geerlingguy/docker-${distro}-ansible:latest" failed and exited with 1 during .