### PR TITLE
Bump minimum ansible version to 2.0

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: PHP PECL extension installation.
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
This change: https://github.com/geerlingguy/ansible-role-php-pecl/blob/63ddbc47b6eb4ab731c65c19c6574472d70e0543/tasks/main.yml#L6

Introduced the `package`  parameter, which isn't valid in ansible 1.9