### PR TITLE
Debian 9 also uses php-pear as CentOS does

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: Include OS-Specific variables.
-  include_vars: "{{ ansible_os_family }}.yml"
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_os_family }}.yml"
 
 - name: Ensure pecl is installed (if configured).
   package:

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,0 +1,2 @@
+---
+php_pecl_package: php-pear


### PR DESCRIPTION
Added a new var file and changed the way var files are imported to include the OS major version.