### PR TITLE
Apt package on Ubuntu bionic is called php-pear, not php-pecl

### DIFF
--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,0 +1,2 @@
+---
+php_pecl_package: php-pear


### PR DESCRIPTION
Without this pull request, Ansible uses the more general ``Debian.yml``. That fails on Ubuntu bionic if `php_pecl_install_pecl: true` is set.

Fix #12