### PR TITLE
Remove dependency on geerlingguy.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ A list of extensions that should be installed via `pecl install`. If you'd like 
       - redis
       - xdebug
 
-## Dependencies
-
-  - geerlingguy.php
-
 ## Example Playbook
 
     - hosts: webservers

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,5 @@
 ---
-dependencies:
-  - geerlingguy.php
+dependencies: []
 
 galaxy_info:
   role_name: php-pecl


### PR DESCRIPTION
Hello,

This is done to match the documentation: 

> "PHP must already be installed on the server."

We expect the same behavior that the composer role:

cf. https://github.com/geerlingguy/ansible-role-composer/blob/master/meta/main.yml